### PR TITLE
Enforce confirmation dialog for all ticket closings via button

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -83,6 +83,12 @@
   - Replaced all usages of `Guid.NewGuid` with `Guid.CreateVersion7`.
   - Added a new database trigger to automatically set IDs for entities if not provided.
 - **Public Discord Transcript Page View:** Implemented a public page for viewing Discord transcripts.
+- **Ticket Closing Confirmation:**
+  - Enforced a confirmation dialog for all ticket closings initiated via button interactions in the initial ticket message.
+  - Removed the direct close functionality from the "Close Ticket" button.
+  - Renamed the "Close Ticket with Reason" button to "Close Ticket" for clarity.
+  - Made the closing reason field in the confirmation modal optional.
+  This change ensures users always confirm ticket closures, preventing accidental or unintended closures.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## **v2.0**
 
 ### **General Improvements**
+
 - Refactored the entire bot code to align with breaking changes and new features introduced in the updated **DSharpPlus v5.x.x-nightly** version.
 - Improved code structure and ensured compatibility with the latest DSharpPlus API.
 - Removed unused and empty files, classes, and projects to streamline the codebase.
@@ -22,6 +23,7 @@
 ---
 
 ### **Authentication and Authorization**
+
 - **Discord OAuth2 Authentication**:
   - Added cookie-based session management.
   - Configured access token storage in claims for session-based usage.
@@ -50,6 +52,7 @@
 ---
 
 ### **Features and Enhancements**
+
 - **Navigation and Pages**:
   - Moved the dashboard to `/dashboard` URI.
   - Added a landing page at `/` with a login button.
@@ -71,6 +74,7 @@
   - Increased caching duration for metrics to improve performance.
   - Improved statistic job performance by using `DefaultIfEmpty`, enabling direct DB average calculations.
   - Added default values to the statistic entity for use in the dashboard.
+  - Separated the message line chart into user and moderator messages for more granular insights.
 - **SmartEnum Integration**:
   - Converted `DbType` to a smart enum.
   - Enabled SmartEnum mapping for `DbContext`.
@@ -78,10 +82,12 @@
 - **GuidV7 Implementation**:
   - Replaced all usages of `Guid.NewGuid` with `Guid.CreateVersion7`.
   - Added a new database trigger to automatically set IDs for entities if not provided.
+- **Public Discord Transcript Page View:** Implemented a public page for viewing Discord transcripts.
 
 ---
 
 ### **Bug Fixes**
+
 - Fixed authorization logic to properly handle failed authentication states.
 - Added a new error message for unauthorized access.
 - Fixed a bug where selecting a ticket type did not update the message correctly.
@@ -92,10 +98,14 @@
 - Fixed dashboard UI issues, typos, and separation of average stats.
 - Fixed ticket notes dialog width for better usability.
 - Fixed unnecessary guild option value assignment on the options page.
+- **Concurrency Issue with DB Context:** Fixed a concurrency issue that could occur with the database context.
+- **Stack Overflow Error with `GetNow` Custom Date Function:** Resolved a stack overflow error that could occur with the `GetNow` custom date function.
+- **Metric Response Mod Message Chart Data Assignment Issue:** Fixed an issue where metric response mod message chart data was not being assigned correctly.
 
 ---
 
 ### **UI and UX Improvements**
+
 - Updated the option page to make labels more descriptive.
 - Updated team management methods and UI to reflect new access control logic.
 - Improved UI consistency across the application.
@@ -108,9 +118,16 @@
 ---
 
 ### **Documentation**
+
 - Improved project documentation:
   - Separated some headers into their own markdown files for better organization.
   - Added direct links to the `img` folder instead of embedding images in markdown.
   - Created `ROADMAP.md` to outline future plans and features.
   - Created `COMMANDS.md` to document available commands.
   - Updated README.md with new details and images.
+  - **README.md Update:** Removed `ROADMAP.md` and moved all roadmap elements to GitHub Issues. This centralizes feature planning and tracking within GitHub's issue management system.
+
+### **Build and Automation**
+
+- **Automated Release Workflow:** Added and configured a `.NET Release` GitHub Actions workflow (`dotnet-release.yml`) to automatically create releases on commits to the `master` branch. The workflow uses the version specified in the `.csproj` file to generate the release. This automates the release process and ensures that releases are consistently versioned.
+- **Removed `commit cs proj` Script:** Removed the `commit cs proj` script, as the automated release workflow now handles version updates and release creation.

--- a/src/Modmail.NET.Web.Blazor/Modmail.NET.Web.Blazor.csproj
+++ b/src/Modmail.NET.Web.Blazor/Modmail.NET.Web.Blazor.csproj
@@ -5,7 +5,7 @@
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>13</LangVersion>
-        <Version>2.0.0-beta9</Version>
+        <Version>2.0.0-beta10</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Modmail.NET.Web.Blazor/Modmail.NET.Web.Blazor.csproj
+++ b/src/Modmail.NET.Web.Blazor/Modmail.NET.Web.Blazor.csproj
@@ -44,7 +44,7 @@
         <PackageReference Include="Polly.Core" Version="8.5.2"/>
         <PackageReference Include="Polly.Extensions" Version="8.5.2"/>
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0"/>
-        <PackageReference Include="Radzen.Blazor" Version="6.3.3"/>
+        <PackageReference Include="Radzen.Blazor" Version="6.3.4" />
         <PackageReference Include="Scrutor" Version="6.0.1"/>
         <PackageReference Include="Serilog" Version="4.2.0"/>
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0"/>

--- a/src/Modmail.NET/Features/Ticket/Handlers/ProcessCloseTicketHandler.cs
+++ b/src/Modmail.NET/Features/Ticket/Handlers/ProcessCloseTicketHandler.cs
@@ -27,9 +27,10 @@ public class ProcessCloseTicketHandler : IRequestHandler<ProcessCloseTicketComma
     var closerUserId = request.CloserUserId == 0
                          ? _bot.Client.CurrentUser.Id
                          : request.CloserUserId;
-    var closeReason = string.IsNullOrEmpty(request.CloseReason)
-                        ? LangProvider.This.GetTranslation(LangKeys.NoReasonProvided)
-                        : request.CloseReason;
+    var closeReason = request.CloseReason?.Trim();
+    if (string.IsNullOrEmpty(closeReason)) {
+      closeReason = null;
+    }
     var closerUser = await _sender.Send(new GetDiscordUserInfoQuery(closerUserId), cancellationToken);
     ArgumentNullException.ThrowIfNull(closerUser);
 

--- a/src/Modmail.NET/Modmail.NET.csproj
+++ b/src/Modmail.NET/Modmail.NET.csproj
@@ -41,7 +41,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.3"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3"/>
         <PackageReference Include="Polly" Version="8.5.2"/>
-        <PackageReference Include="Radzen.Blazor" Version="6.3.3"/>
+        <PackageReference Include="Radzen.Blazor" Version="6.3.4" />
         <PackageReference Include="Riok.Mapperly" Version="4.2.0"/>
         <PackageReference Include="Serilog" Version="4.2.0"/>
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1"/>

--- a/src/Modmail.NET/Modmail.NET.csproj
+++ b/src/Modmail.NET/Modmail.NET.csproj
@@ -6,7 +6,7 @@
         <Nullable>disable</Nullable>
         <Deterministic>false</Deterministic>
         <LangVersion>13</LangVersion>
-        <Version>2.0.0-beta9</Version>
+        <Version>2.0.0-beta10</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Modmail.NET/ModmailEventHandlers.cs
+++ b/src/Modmail.NET/ModmailEventHandlers.cs
@@ -166,20 +166,7 @@ public class ModmailEventHandlers
                           args.Message?.Id);
           break;
         }
-        case "close_ticket": {
-          //close ticket with button
-          await args.Interaction.CreateResponseAsync(DiscordInteractionResponseType.UpdateMessage);
-          var ticketIdParam = parameters[0];
-          var ticketId = Guid.Parse(ticketIdParam);
-          await sender.Send(new ProcessCloseTicketCommand(ticketId, args.User.Id, null, args.Channel));
-          Log.Information(logMessage,
-                          args.Interaction?.Data?.CustomId,
-                          args.User?.Id,
-                          args.Channel?.Id,
-                          args.Interaction?.Id,
-                          args.Message?.Id);
-          break;
-        }
+        case "close_ticket": // This must stay due to deprecation and support for existing tickets (v2.0 beta)
         case "close_ticket_with_reason": {
           var ticketIdParam = parameters[0];
           var ticketId = Guid.Parse(ticketIdParam);

--- a/src/Modmail.NET/Static/Modals.cs
+++ b/src/Modmail.NET/Static/Modals.cs
@@ -20,13 +20,13 @@ public static class Modals
 
   public static DiscordInteractionResponseBuilder CreateCloseTicketWithReasonModal(Guid ticketId) {
     var modal = new DiscordInteractionResponseBuilder()
-                .WithTitle(LangKeys.CloseTicketWithReason.GetTranslation())
+                .WithTitle(LangKeys.CloseTicket.GetTranslation())
                 .WithCustomId(UtilInteraction.BuildKey("close_ticket_with_reason", ticketId))
                 .AddComponents(new DiscordTextInputComponent(LangKeys.Reason.GetTranslation(),
                                                              "reason",
                                                              LangKeys.EnterReasonForClosingThisTicket.GetTranslation(),
                                                              style: DiscordTextInputStyle.Paragraph,
-                                                             min_length: 10,
+                                                             required: false,
                                                              max_length: 500));
     return modal;
   }

--- a/src/Modmail.NET/Static/TicketResponses.cs
+++ b/src/Modmail.NET/Static/TicketResponses.cs
@@ -25,12 +25,8 @@ public static class TicketResponses
     var messageBuilder = new DiscordMessageBuilder()
                          .AddEmbed(embed)
                          .AddComponents(new DiscordButtonComponent(DiscordButtonStyle.Danger,
-                                                                   UtilInteraction.BuildKey("close_ticket", ticketId.ToString()),
-                                                                   LangKeys.CloseTicket.GetTranslation(),
-                                                                   emoji: new DiscordComponentEmoji("🔒")),
-                                        new DiscordButtonComponent(DiscordButtonStyle.Danger,
                                                                    UtilInteraction.BuildKey("close_ticket_with_reason", ticketId.ToString()),
-                                                                   LangKeys.CloseTicketWithReason.GetTranslation(),
+                                                                   LangKeys.CloseTicket.GetTranslation(),
                                                                    emoji: new DiscordComponentEmoji("🔒"))
                                        );
 


### PR DESCRIPTION
- Removed direct ticket closing via "Close Ticket" button.
- Renamed "Close Ticket with Reason" button to "Close Ticket".
- Closing reason in the modal is now optional. This ensures users always confirm ticket closures when using button interactions in the initial ticket message.
- Fixed version bump script
- Updated changelogs accordingly
- Set version to 2.0.0-beta10